### PR TITLE
Search with wildcards / prefix

### DIFF
--- a/lib/PackedTrie.js
+++ b/lib/PackedTrie.js
@@ -164,7 +164,7 @@ class PackedTrie {
      * @return {Boolean}
      */
     test(string) {
-        let {
+        const {
             data,
             offset,
             table,
@@ -179,12 +179,9 @@ class PackedTrie {
         let wordPointer = 0;
 
         // Test every character, with a terminal at the end
-        let match = string.split('').concat(TERMINAL).every(char => {
-            // TODO is binary search possible within blocks? Not sure if the
-            // encoder guarantees ordering, plus there's no indication how long
-            // a block is, so it'd require extra overhead for each block.
+        const match = string.split('').concat(TERMINAL).every(char => {
             while (true) {
-                let queryCharId = table[char];
+                const queryCharId = table[char];
 
                 // Exit immediately if the char was not found in the table,
                 // (or if it was the TERMINAL character, which has a code of 0)
@@ -192,23 +189,23 @@ class PackedTrie {
                     return false;
                 }
 
-                let bits = wordPointer * wordWidth;
-                let chunk = readBits(data, bits, wordWidth);
+                const bits = wordPointer * wordWidth;
+                const chunk = readBits(data, bits, wordWidth);
 
                 // Read the character index
-                let charIdx = (chunk >> charShift) & charMask;
+                const charIdx = (chunk >> charShift) & charMask;
 
                 // If this character is matched, jump to the pointer given in
                 // this node.
                 if (charIdx === queryCharId) {
-                    let pointer = (chunk >> pointerShift) & pointerMask;
+                    const pointer = (chunk >> pointerShift) & pointerMask;
                     wordPointer += offset + pointer;
                     return true;
                 }
 
                 // If this wasn't a match, check if this was the last key in
                 // the block.
-                let last = chunk & lastMask;
+                const last = chunk & lastMask;
 
                 // If this was the last node, the word was not found.
                 if (last) {

--- a/lib/PackedTrie.js
+++ b/lib/PackedTrie.js
@@ -122,6 +122,12 @@ class PackedTrie {
         }, { [TERMINAL]: 0 });
 
         /**
+         * Inverse of character table, mapping integer ID to character.
+         * @type {Array}
+         */
+        this.inverseTable = [TERMINAL].concat(charTable.split(''));
+
+        /**
          * Number of bits in one word
          * @type {Number}
          */
@@ -159,15 +165,45 @@ class PackedTrie {
     }
 
     /**
-     * Test whether trie contains the given string.
-     * @param  {String} string
+     * Test membership in the trie.
+     * @param  {String} string - Search query
+     * @param  {String?} opts.wildcard - See PackedTrie#search wildcard doc
+     * @param  {Boolean?} opts.prefix - See PackedTrie#search prefix doc
      * @return {Boolean}
      */
-    test(string) {
+    test(string, {wildcard, prefix} = {wildcard: null, prefix: false}) {
+        // Delegate to #search with early exit. Could write an optimized path,
+        // especially for the prefix search case.
+        return this.search(string, {wildcard, prefix, first: true}) !== null;
+    }
+
+    /**
+     * Query for matching words in the trie.
+     * @param  {String} string - Search query
+     * @param  {String?} opts.wildcard - Wildcard to use for fuzzy matching.
+     *                                   Default is no wildcard; only match
+     *                                   literal query.
+     * @param  {Boolean?} opts.prefix - Perform prefix search (returns true if
+     *                                  any word exists in the trie starts with
+     *                                  the search query). Default is false;
+     *                                  only match the full query.
+     * @param  {Boolean} opts.first - Return only first match that is found,
+     *                                short-circuiting the search. Default is
+     *                                false; return all matches.
+     * @return {String?|String[]} - Return an optional string result when in
+     *                              first-only mode; otherwise return a list
+     *                              of strings that match the query.
+     */
+    search(string, {wildcard, prefix, first} = {wildcard: null, prefix: false, first: false}) {
+        if (wildcard && wildcard.length !== 1) {
+            throw new Error(`Wilcard must be a single character; got ${wildcard}`);
+        }
+
         const {
             data,
             offset,
             table,
+            inverseTable,
             wordWidth,
             lastMask,
             pointerShift,
@@ -176,17 +212,32 @@ class PackedTrie {
             charMask
         } = this;
 
-        let wordPointer = 0;
+        // List of matches found in the search.
+        const matches = [];
 
-        // Test every character, with a terminal at the end
-        const match = string.split('').concat(TERMINAL).every(char => {
+        // Search queue.
+        const queue = [{pointer: 0, memo: '', depth: 0}];
+        const lastDepth = string.length;
+
+        // Do a BFS over nodes for the search query.
+        while (queue.length) {
+            const node = queue.shift();
+            const isLast = node.depth >= lastDepth;
+            const token = isLast ? TERMINAL : string[node.depth];
+            // Flag for matching anything. Note that the overflow beyond the
+            // length of the query in a prefix search behaves as a wildcard.
+            const isWild = token === wildcard || (prefix && isLast);
+            // We're committed to an O(N) scan over the entire node even in
+            // the simple literal-search case, since our structure doesn't
+            // currently guarantee any child ordering.
+            // TODO(joen) ordering is a potential future format optimization.
+            let wordPointer = node.pointer;
             while (true) {
-                const queryCharId = table[char];
-
-                // Exit immediately if the char was not found in the table,
-                // (or if it was the TERMINAL character, which has a code of 0)
-                if (queryCharId === undefined) {
-                    return false;
+                // Optimization: Exit immediately if the char was not found in
+                // the table (meaning there can't be any children in the trie
+                // with this character). Exception is wildcards.
+                if (!isWild && !table.hasOwnProperty(token)) {
+                    break;
                 }
 
                 const bits = wordPointer * wordWidth;
@@ -197,10 +248,34 @@ class PackedTrie {
 
                 // If this character is matched, jump to the pointer given in
                 // this node.
-                if (charIdx === queryCharId) {
+                if (isWild || charIdx === table[token]) {
                     const pointer = (chunk >> pointerShift) & pointerMask;
-                    wordPointer += offset + pointer;
-                    return true;
+                    // Find the next char with an inverse map, since we might
+                    // be using a wildcard search.
+                    const newChar = inverseTable[charIdx];
+                    // Stopping condition: searching last block and we hit a terminal
+                    if (isLast && newChar === TERMINAL) {
+                        // Optimization: early exit if we only need first match.
+                        if (first) {
+                            return node.memo;
+                        }
+                        // Store this match.
+                        matches.push(node.memo);
+                        // If we're not matching everything, break out of the
+                        // inner loop.
+                        if (!isWild) {
+                            break;
+                        }
+                    }
+
+                    // Push next node for search, if it's non-terminal.
+                    if (newChar !== TERMINAL) {
+                        queue.push({
+                            pointer: wordPointer + offset + pointer,
+                            depth: node.depth + 1,
+                            memo: node.memo + newChar,
+                        });
+                    }
                 }
 
                 // If this wasn't a match, check if this was the last key in
@@ -209,16 +284,18 @@ class PackedTrie {
 
                 // If this was the last node, the word was not found.
                 if (last) {
-                    return false;
+                    break;
                 }
                 // Otherwise increment the pointer to the next sibling key
                 else {
                     wordPointer += 1;
                 }
             }
-        });
+        }
 
-        return match;
+        // If first was requested it should have returned by now. Otherwise
+        // return the matches list, which may be empty.
+        return first ? null : matches;
     }
 
 }

--- a/lib/PackedTrie.test.js
+++ b/lib/PackedTrie.test.js
@@ -8,8 +8,8 @@ describe('PackedTrie', () => {
 
     describe('constructor', () => {
         it('should parse header fields on init', () => {
-            let encoded = 'BAAAAABAwIfboarzKTbjds1FDB';
-            let trie = new PackedTrie(encoded);
+            const encoded = 'BAAAAABAwIfboarzKTbjds1FDB';
+            const trie = new PackedTrie(encoded);
 
             assert.strictEqual(trie.offset, 1);
             assert.deepEqual(trie.table, {
@@ -31,15 +31,15 @@ describe('PackedTrie', () => {
         });
 
         it('should throw a version mismatch error if encoded string differs from reader version', () => {
-            let encoded = 'BD/wAABAwIfboarzKTbjds1FDB';
+            const encoded = 'BD/wAABAwIfboarzKTbjds1FDB';
             assert.throws(() => new PackedTrie(encoded));
         });
     });
 
     describe('test', () => {
         it('should determine whether an item is in the Trie', () => {
-            let encoded = 'BAAAAABAwIfboarzKTbjds1FDB';
-            let trie = new PackedTrie(encoded);
+            const encoded = 'BAAAAABAwIfboarzKTbjds1FDB';
+            const trie = new PackedTrie(encoded);
 
             ['foo', 'bar', 'baz'].forEach(w => assert(trie.test(w)));
             ['fu', 'boer', 'batz'].forEach(w => assert(!trie.test(w)));
@@ -52,16 +52,80 @@ describe('PackedTrie', () => {
                 ['agricola', 'agricolae', 'agricolae', 'agricolam', 'agricolā'],
                 ['любить', 'люблю', 'любишь', 'любит', 'любим', 'любите', 'любят']
             ].forEach(words => {
-                let sdrow = words.slice().map(w => w.split('').reverse().join(''));
-                let trie = new Trie();
+                const sdrow = words.slice().map(w => w.split('').reverse().join(''));
+                const trie = new Trie();
                 words.forEach(w => trie.insert(w));
                 words.forEach(w => assert(trie.test(w)));
                 sdrow.forEach(s => assert(!trie.test(s)));
-                let encoded = trie.freeze().encode();
-                let packed = new PackedTrie(encoded);
+                const encoded = trie.freeze().encode();
+                const packed = new PackedTrie(encoded);
                 words.forEach(w => assert(packed.test(w)));
                 sdrow.forEach(s => assert(!packed.test(s)));
             });
+        });
+
+        it('returns true for fuzzy matches when wildcard is given', () => {
+            const trie = new Trie();
+            trie.insert('foo');
+            trie.insert('bar');
+            trie.insert('bop');
+            trie.insert('baz');
+            const packed = new PackedTrie(trie.freeze().encode());
+
+            assert(packed.test('***', {wildcard: '*'}));
+            assert(packed.test('**r', {wildcard: '*'}));
+            assert(packed.test('*az', {wildcard: '*'}));
+            assert(packed.test('f**', {wildcard: '*'}));
+            assert(packed.test('f*o', {wildcard: '*'}));
+            assert(!packed.test('**x', {wildcard: '*'}));
+        });
+
+        it('returns true for partial matches when searching over prefixes', () => {
+            const trie = new Trie();
+            trie.insert('foo');
+            trie.insert('food');
+            trie.insert('foodology');
+            const packed = new PackedTrie(trie.freeze().encode());
+
+            assert(packed.test('fo', {prefix: true}));
+            assert(packed.test('foodolog', {prefix: true}));
+            assert(!packed.test('fob', {prefix: true}));
+        });
+
+        it('returns correct value for complex options cases', () => {
+            const trie = new Trie();
+            trie.insert('foo');
+            trie.insert('bar');
+            trie.insert('foobar');
+            const packed = new PackedTrie(trie.freeze().encode());
+
+            assert(packed.test('foo', {wildcard: '*'}));
+            assert(packed.test('bar', {wildcard: '*'}));
+            assert(!packed.test('foob', {wildcard: '*', prefix: false}));
+            assert(packed.test('foobar', {wildcard: '*', prefix: false}));
+            assert(packed.test('foob*', {wildcard: '*', prefix: true}));
+            assert(!packed.test('foob*', {wildcard: '*', prefix: false}));
+            assert(packed.test('**ob*', {wildcard: '*', prefix: true}));
+        });
+    });
+
+    describe('search', () => {
+        const encoded = 'BMAAAAABAQfbgtoarleFBKNiPVzXZyxVzPV6vfbxWqzeazC0VCYQloNBYJg4BAIB';
+        const trie = new PackedTrie(encoded);
+
+        it('returns all matching values with wildcard', () => {
+            assert.deepEqual(trie.search('*oo', {wildcard: '*'}), ['foo', 'boo', 'goo']);
+            assert.deepEqual(trie.search('*oo', {wildcard: '*', prefix: true}), [
+                'foo', 'boo', 'goo', 'fool', 'tool']);
+            assert.deepEqual(trie.search('f**', {wildcard: '*'}), ['foo', 'far']);
+            assert.deepEqual(trie.search('*x*', {wildcard: '*'}), []);
+        });
+
+        it('returns first match with wildcard', () => {
+            assert(trie.search('f**', {wildcard: '*', first: true}) === 'foo');
+            assert(trie.search('**x', {wildcard: '*', first: true}) === null);
+            assert(trie.search('*', {wildcard: '*', prefix: true}), [
+                'foo', 'bar', 'bare', 'fool', 'goo', 'far', 'boo', 'gar', 'tool']);
         });
     });
 

--- a/lib/Trie.js
+++ b/lib/Trie.js
@@ -69,14 +69,103 @@ class Trie {
     }
 
     /**
-     * Test membership in the trie
-     * @param  {String} string
+     * Test membership in the trie.
+     * @param  {String} string - Search query
+     * @param  {String?} opts.wildcard - See #search wildcard doc
+     * @param  {Boolean?} opts.prefix - See #search prefix doc
      * @return {Boolean}
      */
-    test(string) {
-        let node = this.root;
-        let match = string.split('').every(char => node = node[char]);
-        return !!match && node.hasOwnProperty(TERMINAL);
+    test(string, {wildcard, prefix} = {wildcard: null, prefix: false}) {
+        // When there are no wildcards we can use an optimized search.
+        if (!wildcard) {
+            let node = this.root;
+            const match = string.split('').every(char => node = node[char]);
+            return !!match && (prefix || node.hasOwnProperty(TERMINAL));
+        }
+
+        // Unoptimized path: delegate to #search with short-circuiting.
+        return !!this.search(string, {wildcard, prefix, first: true});
+    }
+
+    /**
+     * Query for matching words in the trie.
+     * @param  {String} string - Search query
+     * @param  {String?} opts.wildcard - Wildcard to use for fuzzy matching.
+     *                                   Default is no wildcard; only match
+     *                                   literal query.
+     * @param  {Boolean?} opts.prefix - Perform prefix search (returns true if
+     *                                  any word exists in the trie starts with
+     *                                  the search query). Default is false;
+     *                                  only match the full query.
+     * @param  {Boolean} opts.first - Return only first match that is found,
+     *                                short-circuiting the search. Default is
+     *                                false; return all matches.
+     * @return {String?|String[]} - Return an optional string result when in
+     *                              first-only mode; otherwise return a list
+     *                              of strings that match the query.
+     */
+    search(string, {wildcard, prefix, first} = {wildcard: null, prefix: false, first: false}) {
+        // Validate wildcard matching.
+        if (wildcard && wildcard.length !== 1) {
+            throw new Error(`Wildcard length must be 1; got ${wildcard.length}`);
+        }
+
+        // List of search hits. Note: not used in `first` mode.
+        const matches = [];
+
+        // Do a BFS over nodes to with fuzzy-matching on the wildcard.
+        const queue = [{data: this.root, depth: 0, memo: ''}];
+        const lastDepth = string.length;
+
+        while (queue.length) {
+            const node = queue.shift();
+            // The search is a hit if we've reached the proper depth and the
+            // node is terminal. The search can break if the query was for
+            // first-only.
+            if (node.depth >= lastDepth) {
+                if (node.data.hasOwnProperty(TERMINAL)) {
+                    if (first) {
+                        return node.memo;
+                    }
+                    // Otherwise store this result and continue searching.
+                    matches.push(node.memo);
+                }
+                // Discard the node and move on if we can; prefix matches need
+                // to traverse everything.
+                if (!prefix) {
+                    continue;
+                }
+            }
+            // Special case: prefix searches overflow the length of the search
+            // queries. Treat these overflowing chars as wildcards.
+            const isPfXOverflow = prefix && node.depth >= lastDepth;
+            // Add any candidate children nodes to the search queue.
+            const token = string[node.depth];
+            // Wildcard could be any child (except terminal).
+            if (token === wildcard || isPfXOverflow) {
+                Object.keys(node.data).forEach(n => {
+                    if (n !== TERMINAL) {
+                        queue.push({
+                            data: node.data[n],
+                            depth: node.depth + 1,
+                            memo: node.memo + n,
+                        });
+                    }
+                });
+            } else {
+                if (node.data.hasOwnProperty(token)) {
+                    queue.push({
+                        data: node.data[token],
+                        depth: node.depth + 1,
+                        memo: node.memo + token,
+                    });
+                }
+            }
+        }
+
+        // A `first` search will have broken out and returned a literal by now;
+        // other searches just return whatever is in matches.
+        return first ? null : matches;
     }
 
     /**

--- a/lib/Trie.js
+++ b/lib/Trie.js
@@ -71,8 +71,8 @@ class Trie {
     /**
      * Test membership in the trie.
      * @param  {String} string - Search query
-     * @param  {String?} opts.wildcard - See #search wildcard doc
-     * @param  {Boolean?} opts.prefix - See #search prefix doc
+     * @param  {String?} opts.wildcard - See Trie#search wildcard doc
+     * @param  {Boolean?} opts.prefix - See Trie#search prefix doc
      * @return {Boolean}
      */
     test(string, {wildcard, prefix} = {wildcard: null, prefix: false}) {

--- a/lib/Trie.test.js
+++ b/lib/Trie.test.js
@@ -10,15 +10,15 @@ import assert from 'assert';
  * @return {String[]}
  */
 function flatKeys(trie) {
-    let nodes = [];
-    let keys = [];
+    const nodes = [];
+    const keys = [];
 
     (function walk(node, i = 0) {
         Object.keys(node).forEach(key => {
             if (key.substr(0, 2) === '__') {
                 return;
             }
-            let current = node[key];
+            const current = node[key];
             if (!nodes.find(x => x === current)) {
                 nodes.push(current);
                 keys.push(`${key}_${i}`);
@@ -45,7 +45,7 @@ describe('Trie', () => {
 
     describe('constructor', () => {
         it('creates an empty Trie', () => {
-            let trie = new Trie();
+            const trie = new Trie();
             assert(stringifyNoPrivate(trie.root), '{}');
             assert(trie.frozen === false);
         });
@@ -53,7 +53,7 @@ describe('Trie', () => {
 
     describe('insert', () => {
         it('inserts a word into the trie', () => {
-            let trie = new Trie();
+            const trie = new Trie();
             trie.insert('foo');
             assert.strictEqual(
                 stringifyNoPrivate(trie.root),
@@ -62,7 +62,7 @@ describe('Trie', () => {
         });
 
         it('does not create redundant prefixes', () => {
-            let trie = new Trie();
+            const trie = new Trie();
             trie.insert('foo');
             trie.insert('food');
             assert.strictEqual(
@@ -72,7 +72,7 @@ describe('Trie', () => {
         });
 
         it('throws an error if trie is frozen', () => {
-            let trie = new Trie();
+            const trie = new Trie();
             trie.freeze();
             assert.throws(() => trie.insert('foo'));
         });
@@ -80,7 +80,7 @@ describe('Trie', () => {
 
     describe('test', () => {
         it('recalls strings entered into the trie', () => {
-            let trie = new Trie();
+            const trie = new Trie();
 
             trie.insert('foo');
             assert(trie.test('foo'));

--- a/lib/Trie.test.js
+++ b/lib/Trie.test.js
@@ -94,6 +94,70 @@ describe('Trie', () => {
             assert(trie.test('foo'));
             assert(trie.test('bar'));
         });
+
+        it('returns true for fuzzy matches when wildcard is given', () => {
+            const trie = new Trie();
+            trie.insert('foo');
+            trie.insert('bar');
+            trie.insert('bop');
+            trie.insert('baz');
+
+            assert(trie.test('***', {wildcard: '*'}));
+            assert(trie.test('**r', {wildcard: '*'}));
+            assert(trie.test('*az', {wildcard: '*'}));
+            assert(trie.test('f**', {wildcard: '*'}));
+            assert(trie.test('f*o', {wildcard: '*'}));
+            assert(!trie.test('**x', {wildcard: '*'}));
+        });
+
+        it('returns true for partial matches when searching over prefixes', () => {
+            const trie = new Trie();
+            trie.insert('foo');
+            trie.insert('food');
+            trie.insert('foodology');
+
+            assert(trie.test('fo', {prefix: true}));
+            assert(trie.test('foodolog', {prefix: true}));
+            assert(!trie.test('fob', {prefix: true}));
+        });
+
+        it('returns correct value for complex options cases', () => {
+            const trie = new Trie();
+            trie.insert('foo');
+            trie.insert('bar');
+            trie.insert('foobar');
+
+            assert(trie.test('foo', {wildcard: '*'}));
+            assert(trie.test('bar', {wildcard: '*'}));
+            assert(!trie.test('foob', {wildcard: '*', prefix: false}));
+            assert(trie.test('foobar', {wildcard: '*', prefix: false}));
+            assert(trie.test('foob*', {wildcard: '*', prefix: true}));
+            assert(!trie.test('foob*', {wildcard: '*', prefix: false}));
+            assert(trie.test('**ob*', {wildcard: '*', prefix: true}));
+        });
+    });
+
+    describe('search', () => {
+        const strings = ['foo', 'bar', 'bare', 'fool', 'goo', 'far', 'boo', 'gar', 'tool'];
+
+        it('returns all matching values with wildcard', () => {
+            const trie = new Trie();
+            strings.forEach(s => trie.insert(s));
+
+            assert.deepEqual(trie.search('*oo', {wildcard: '*'}), ['foo', 'boo', 'goo']);
+            assert.deepEqual(trie.search('*oo', {wildcard: '*', prefix: true}), [
+                'foo', 'boo', 'goo', 'fool', 'tool']);
+            assert.deepEqual(trie.search('f**', {wildcard: '*'}), ['foo', 'far']);
+            assert.deepEqual(trie.search('*x*', {wildcard: '*'}), []);
+        });
+
+        it('returns first match with wildcard', () => {
+            const trie = new Trie();
+            strings.forEach(s => trie.insert(s));
+            assert(trie.search('f**', {wildcard: '*', first: true}) === 'foo');
+            assert(trie.search('**x', {wildcard: '*', first: true}) === null);
+            assert(trie.search('*', {wildcard: '*', prefix: true}), strings);
+        });
     });
 
     describe('freeze', () => {


### PR DESCRIPTION
fix #1 

Implements `Trie#search` with options for wildcard matching and prefix search. These options can now be used for `Trie#test` as well.

To do: implement the same for `PackedTrie` as well